### PR TITLE
Fix Fabfile

### DIFF
--- a/bin/fabfile.py
+++ b/bin/fabfile.py
@@ -1,26 +1,26 @@
 # We can define a bunch of fabric tasks to help with Sphinx
-# 
+#
 
 import os
 import sys
 
 ROOT           = os.path.realpath(os.path.join(os.path.dirname('.')))
 TMP            = os.path.join(ROOT, 'tmp')
-LATEST_SPHINX  = 'http://www.sphinxsearch.com/downloads/sphinx-0.9.9-rc2.tar.gz'
+LATEST_SPHINX  = "http://sphinxsearch.com/files/archive/sphinx-0.9.9-rc2.tar.gz"
 SPHINX_VERSION = (LATEST_SPHINX.rpartition('/')[2]).rpartition('.tar.')[0]
 TARBALL        = os.path.join(TMP,LATEST_SPHINX.rpartition('/')[2])
 
 INSTALL_ROOT     = '/opt/local'
 
 def create_dirs():
-    local("mkdir -p %s"% TMP)
-    local("mkdir -p %s" % os.path.join(INSTALL_ROOT, 'data/sphinx'))
-    local("mkdir -p %s" % os.path.join(INSTALL_ROOT, 'log/searchd'))
+    os.system("mkdir -p %s"% TMP)
+    os.system("mkdir -p %s" % os.path.join(INSTALL_ROOT, 'data/sphinx'))
+    os.system("mkdir -p %s" % os.path.join(INSTALL_ROOT, 'log/searchd'))
 
 def install_sphinx():
     create_dirs()
     print("Obtaining sphinx")
-    local("wget -P %s %s" % (TMP, LATEST_SPHINX))
-    local("cd %s; tar zxf %s" % (TMP, TARBALL))
+    os.system("wget -P %s %s" % (TMP, LATEST_SPHINX))
+    os.system("cd %s; tar zxf %s" % (TMP, TARBALL))
     #make
-    local("cd %s;./configure --prefix=%s;make;make install"%(os.path.join(TMP, SPHINX_VERSION),INSTALL_ROOT))
+    os.system("cd %s;./configure --prefix=%s;make;make install"%(os.path.join(TMP, SPHINX_VERSION),INSTALL_ROOT))


### PR DESCRIPTION
This commits intends to fix the old fabfile which is used to automate
installation part. Changes done
1.) local() was removed with os.system() , since utlimately it is used
to invoke shell commands and couldn't find any function/module named in
python which does that
2.) Change upstream of downloading sphinx. At the time of writing
version 0.9.9 is more than 2 years old and have archived.

Affects `bin/fabfile.py`

I am also thinking out to verify build process by running automated tests post commit on Github using something like Travis CI (or another CI system as long as it works) ?