### PR TITLE
Update stable Sugar version to 0.112

### DIFF
--- a/aslo/config.php
+++ b/aslo/config.php
@@ -265,7 +265,7 @@ define('SITE_MIME', 'application/vnd.olpc-sugar'); // application/x-xpinstall
 define('SITE_ORG', 'Sugar Labs'); // Mozilla
 define('SSITE_URL', 'https://activities.sugarlabs.org');
 define('HELP_IRC', '#Sugar on irc.freenode.nt');
-define('SITE_SUGAR_STABLE', '0.110');
+define('SITE_SUGAR_STABLE', '0.112');
 
 define('SITE_APP', 1); // 1
 


### PR DESCRIPTION
For merge and promotion to production on 9th October after release announcement.

Reference: https://wiki.sugarlabs.org/go/Development_Team/Release#Glucose_.28base.29_modules